### PR TITLE
🐛 Fix ImportError: Remove unavailable ToolResult import

### DIFF
--- a/src/beeai_agents/agent.py
+++ b/src/beeai_agents/agent.py
@@ -21,7 +21,6 @@ from beeai_framework.backend.message import UserMessage, AssistantMessage
 from beeai_framework.memory import UnconstrainedMemory
 from beeai_framework.tools import Tool, StringToolOutput, ToolRunOptions
 from beeai_framework.tools.think import ThinkTool
-from beeai_framework.tools.types import ToolResult
 from beeai_framework.context import RunContext
 from beeai_framework.emitter import Emitter
 from dotenv import load_dotenv


### PR DESCRIPTION
## 🐛 Fix ImportError: Remove unavailable ToolResult import

### Problem
After merging the abstract method fixes, the agent still fails to start with:
```
ImportError: cannot import name 'ToolResult' from 'beeai_framework.tools.types'
```

### Root Cause
The `ToolResult` class doesn't exist in the current version of the BeeAI framework. It was incorrectly imported but never used.

### Solution
This PR removes the problematic import:

#### Changes:
- ❌ **Removed**: `from beeai_framework.tools.types import ToolResult`  
- ✅ **Kept**: All necessary imports (`StringToolOutput`, `Tool`, `ToolRunOptions`)
- ✅ **Verified**: No functionality loss - `StringToolOutput` is the correct return type

### Testing Results
**Before Fix:**
```
ImportError: cannot import name 'ToolResult' from 'beeai_framework.tools.types'
```

**After Fix:**
```
✅ Agent starts successfully
✅ All imports resolve correctly
✅ No functionality impacted
```

### Files Changed
- `src/beeai_agents/agent.py`: Removed unused ToolResult import

---

**Fixes**: ImportError preventing agent startup after abstract method fix  
**Dependencies**: Requires merged PR #2 for abstract method implementations  
**Ready for**: Immediate merge to resolve startup issue